### PR TITLE
10.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changes to @csstools/normalize.css
 
-### 10.0.0 (May 14, 2019)
+### 10.1.0 (June 3, 2019)
+
+- Fixed: `Edge` comments without `Chrome` are are changed to `Edge 18-`.
+- Fixed: `Chrome` comments without `Edge` have `Edge` added.
+- Fixed: Nested list `dl` normalizations split.
+- Fixed: Logical `margin-block` normalization changed to `margin`.
+
+### 10.0.0 (May 16, 2019)
 
 - Added: Removal of the margin on nested lists in Chrome and Safari.
 - Added: opinionated.css, normalize.css with classic opinionated styles.
@@ -23,7 +30,7 @@
 > “csstools” tag. I hope one day our differences are resolved and the projects
 > will be one again.
 >
-> For reference:
+> For reference within this project:
 > normalize.css resolves bugs and common browser inconsistencies.
 > opinionated.css does the same while preserving the classic opinionated styles.
 

--- a/normalize.css
+++ b/normalize.css
@@ -18,7 +18,7 @@ html {
 
 /**
  * Correct the font size and margin on `h1` elements within `section` and
- * `article` contexts in Chrome, Firefox, and Safari.
+ * `article` contexts in Chrome, Edge, Firefox, and Safari.
  */
 
 h1 {
@@ -30,25 +30,31 @@ h1 {
  * ========================================================================== */
 
 /**
- * Remove the margin on nested lists in Chrome and Safari.
+ * Remove the margin on nested lists in Chrome, Edge, IE, and Safari.
  */
 
 dl dl,
 dl ol,
 dl ul,
 ol dl,
+ul dl {
+  margin: 0;
+}
+
+/**
+ * Remove the margin on nested lists in Edge 18- and IE.
+ */
+
 ol ol,
 ol ul,
-ul dl,
 ul ol,
 ul ul {
-  margin-block-start: 0;
-  margin-block-end: 0;
+  margin: 0;
 }
 
 /**
  * 1. Add the correct box sizing in Firefox.
- * 2. Show the overflow in Edge and IE.
+ * 2. Show the overflow in Edge 18- and IE.
  */
 
 hr {
@@ -87,7 +93,7 @@ a {
 }
 
 /**
- * Add the correct text decoration in Edge, IE, Opera, and Safari.
+ * Add the correct text decoration in Edge 18-, IE, and Safari.
  */
 
 abbr[title] {
@@ -176,7 +182,7 @@ select {
 
 /**
  * 1. Show the overflow in IE.
- * 2. Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 2. Remove the inheritance of text transform in Edge 18-, Firefox, and IE.
  */
 
 button {
@@ -204,7 +210,7 @@ fieldset {
 }
 
 /**
- * Show the overflow in Edge and IE.
+ * Show the overflow in Edge 18- and IE.
  */
 
 input {
@@ -212,7 +218,7 @@ input {
 }
 
 /**
- * 1. Correct the text wrapping in Edge and IE.
+ * 1. Correct the text wrapping in Edge 18- and IE.
  * 2. Correct the color inheritance from `fieldset` elements in IE.
  */
 
@@ -225,8 +231,8 @@ legend {
 }
 
 /**
- * 1. Add the correct display in Edge and IE.
- * 2. Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ * 1. Add the correct display in Edge 18- and IE.
+ * 2. Add the correct vertical alignment in Chrome, Edge, and Firefox.
  */
 
 progress {
@@ -264,7 +270,7 @@ textarea {
 }
 
 /**
- * 1. Correct the odd appearance in Chrome and Safari.
+ * 1. Correct the odd appearance in Chrome, Edge, and Safari.
  * 2. Correct the outline style in Safari.
  */
 
@@ -292,7 +298,7 @@ textarea {
 }
 
 /**
- * Remove the inner padding in Chrome and Safari on macOS.
+ * Remove the inner padding in Chrome, Edge, and Safari on macOS.
  */
 
 ::-webkit-search-decoration {
@@ -338,7 +344,7 @@ textarea {
  * ========================================================================== */
 
 /*
- * Add the correct display in Edge and IE.
+ * Add the correct display in Edge 18- and IE.
  */
 
 details {
@@ -346,7 +352,7 @@ details {
 }
 
 /*
- * Add the correct styles in Edge, IE, and Safari.
+ * Add the correct styles in Edge 18-, IE, and Safari.
  */
 
 dialog {

--- a/opinionated.css
+++ b/opinionated.css
@@ -26,7 +26,7 @@ body {
 
 /**
  * Correct the font size and margin on `h1` elements within `section` and
- * `article` contexts in Chrome, Firefox, and Safari.
+ * `article` contexts in Chrome, Edge, Firefox, and Safari.
  */
 
 h1 {
@@ -38,25 +38,31 @@ h1 {
  * ========================================================================== */
 
 /**
- * Remove the margin on nested lists in Chrome and Safari.
+ * Remove the margin on nested lists in Chrome, Edge, IE, and Safari.
  */
 
 dl dl,
 dl ol,
 dl ul,
 ol dl,
+ul dl {
+  margin: 0;
+}
+
+/**
+ * Remove the margin on nested lists in Edge 18- and IE.
+ */
+
 ol ol,
 ol ul,
-ul dl,
 ul ol,
 ul ul {
-  margin-block-start: 0;
-  margin-block-end: 0;
+  margin: 0;
 }
 
 /**
  * 1. Add the correct box sizing in Firefox.
- * 2. Show the overflow in Edge and IE.
+ * 2. Show the overflow in Edge 18- and IE.
  */
 
 hr {
@@ -95,7 +101,7 @@ a {
 }
 
 /**
- * Add the correct text decoration in Edge, IE, Opera, and Safari.
+ * Add the correct text decoration in Edge 18-, IE, and Safari.
  */
 
 abbr[title] {
@@ -184,7 +190,7 @@ select {
 
 /**
  * 1. Show the overflow in IE.
- * 2. Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 2. Remove the inheritance of text transform in Edge 18-, Firefox, and IE.
  */
 
 button {
@@ -212,7 +218,7 @@ fieldset {
 }
 
 /**
- * Show the overflow in Edge and IE.
+ * Show the overflow in Edge 18- and IE.
  */
 
 input {
@@ -220,7 +226,7 @@ input {
 }
 
 /**
- * 1. Correct the text wrapping in Edge and IE.
+ * 1. Correct the text wrapping in Edge 18- and IE.
  * 2. Correct the color inheritance from `fieldset` elements in IE.
  */
 
@@ -233,8 +239,8 @@ legend {
 }
 
 /**
- * 1. Add the correct display in Edge and IE.
- * 2. Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ * 1. Add the correct display in Edge 18- and IE.
+ * 2. Add the correct vertical alignment in Chrome, Edge, and Firefox.
  */
 
 progress {
@@ -276,7 +282,7 @@ textarea {
 }
 
 /**
- * 1. Correct the odd appearance in Chrome and Safari.
+ * 1. Correct the odd appearance in Chrome, Edge, and Safari.
  * 2. Correct the outline style in Safari.
  */
 
@@ -304,7 +310,7 @@ textarea {
 }
 
 /**
- * Remove the inner padding in Chrome and Safari on macOS.
+ * Remove the inner padding in Chrome, Edge, and Safari on macOS.
  */
 
 ::-webkit-search-decoration {
@@ -350,7 +356,7 @@ textarea {
  * ========================================================================== */
 
 /*
- * Add the correct display in Edge and IE.
+ * Add the correct display in Edge 18- and IE.
  */
 
 details {
@@ -358,7 +364,7 @@ details {
 }
 
 /*
- * Add the correct styles in Edge, IE, and Safari.
+ * Add the correct styles in Edge 18-, IE, and Safari.
  */
 
 dialog {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@csstools/normalize.css",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "A cross-browser CSS foundation",
   "author": "Jonathan Neal <jonathantneal@hotmail.com>",
   "contributors": [


### PR DESCRIPTION
- Fixed: `Edge` comments without `Chrome` are are changed to `Edge 18-`.
- Fixed: `Chrome` comments without `Edge` have `Edge` added.
- Fixed: Nested list `dl` normalizations split.
- Fixed: Logical `margin-block` normalization changed to `margin`.