### PR TITLE
Normalize table properties across browsers

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -142,7 +142,10 @@ table {
  * Correct table border color inheritance in all browsers.
  */
 
-table, thead, tbody, tfoot {
+table,
+thead,
+tbody,
+tfoot {
   border-color: inherit;
 }
 

--- a/normalize.css
+++ b/normalize.css
@@ -130,6 +130,22 @@ small {
   font-size: 80%;
 }
 
+/**
+ * Remove text indentation from table contents in Chrome and Safari.
+ */
+
+table {
+  text-indent: 0;
+}
+
+/**
+ * Correct table border color inheritance in all browsers.
+ */
+
+table, thead, tbody, tfoot {
+  border-color: inherit;
+}
+
 /* Embedded content
  * ========================================================================== */
 

--- a/normalize.css
+++ b/normalize.css
@@ -171,13 +171,13 @@ svg:not(:root) {
  * ========================================================================== */
 
 /**
- * 1. Remove text indentation from table contents in Chrome and Safari.
- * 2. Correct table border color inheritance in all Chrome and Safari.
+ * 1. Correct table border color inheritance in all Chrome and Safari.
+ * 2. Remove text indentation from table contents in Chrome and Safari.
  */
 
 table {
-	text-indent: 0; /* 1 */
-	border-color: inherit; /* 2 */
+  border-color: inherit; /* 1 */
+  text-indent: 0; /* 2 */
 }
 
 /* Forms

--- a/normalize.css
+++ b/normalize.css
@@ -130,25 +130,6 @@ small {
   font-size: 80%;
 }
 
-/**
- * Remove text indentation from table contents in Chrome and Safari.
- */
-
-table {
-  text-indent: 0;
-}
-
-/**
- * Correct table border color inheritance in all browsers.
- */
-
-table,
-thead,
-tbody,
-tfoot {
-  border-color: inherit;
-}
-
 /* Embedded content
  * ========================================================================== */
 
@@ -184,6 +165,19 @@ img {
 
 svg:not(:root) {
   overflow: hidden;
+}
+
+/* Tabular data
+ * ========================================================================== */
+
+/**
+ * 1. Remove text indentation from table contents in Chrome and Safari.
+ * 2. Correct table border color inheritance in all Chrome and Safari.
+ */
+
+table {
+	text-indent: 0; /* 1 */
+	border-color: inherit; /* 2 */
 }
 
 /* Forms


### PR DESCRIPTION
- Set `text-indent: 0` for `table` elements, as [in the UA sheet of Firefox](https://dxr.mozilla.org/mozilla-central/rev/c68fe15a81fc2dc9fc5765f3be2573519c09b6c1/layout/style/res/html.css#269)
  - [Chrome issue](https://bugs.chromium.org/p/chromium/issues/detail?id=999088)
  - [Safari issue](https://bugs.webkit.org/show_bug.cgi?id=201297)
- Inherit table border colors consistently
  - [Chrome issue](https://bugs.chromium.org/p/chromium/issues/detail?id=935729)
  - [Safari issue](https://bugs.webkit.org/show_bug.cgi?id=195016)