### PR TITLE
table border-color currentcolor?

### DIFF
--- a/evergreen.css
+++ b/evergreen.css
@@ -110,12 +110,12 @@
  * ========================================================================== */
 
 /**
- * 1. Correct table border color inheritance in all Chrome, Edge, and Safari.
+ * 1. Correct table border color in Chrome, Edge, and Safari.
  * 2. Remove text indentation from table contents in Chrome, Edge, and Safari.
  */
 
 :where(table) {
-  border-color: inherit; /* 1 */
+  border-color: currentColor; /* 1 */
   text-indent: 0; /* 2 */
 }
 

--- a/normalize.css
+++ b/normalize.css
@@ -169,7 +169,7 @@ svg:not(:root) {
  * ========================================================================== */
 
 /**
- * 1. Correct table border color in all Chrome, Edge, and Safari.
+ * 1. Correct table border color in Chrome, Edge, and Safari.
  * 2. Remove text indentation from table contents in Chrome, Edge, and Safari.
  */
 

--- a/normalize.css
+++ b/normalize.css
@@ -169,12 +169,12 @@ svg:not(:root) {
  * ========================================================================== */
 
 /**
- * 1. Correct table border color inheritance in all Chrome, Edge, and Safari.
+ * 1. Correct table border color in all Chrome, Edge, and Safari.
  * 2. Remove text indentation from table contents in Chrome, Edge, and Safari.
  */
 
 table {
-  border-color: inherit; /* 1 */
+  border-color: currentColor; /* 1 */
   text-indent: 0; /* 2 */
 }
 

--- a/opinionated.css
+++ b/opinionated.css
@@ -177,12 +177,12 @@ svg:not(:root) {
  * ========================================================================== */
 
 /**
- * 1. Correct table border color inheritance in all Chrome, Edge, and Safari.
+ * 1. Correct table border color in Chrome, Edge, and Safari.
  * 2. Remove text indentation from table contents in Chrome, Edge, and Safari.
  */
 
 table {
-  border-color: inherit; /* 1 */
+  border-color: currentColor; /* 1 */
   text-indent: 0; /* 2 */
 }
 

--- a/opinionated.evergreen.css
+++ b/opinionated.evergreen.css
@@ -123,12 +123,12 @@ audio:not([controls]) {
  * ========================================================================== */
 
 /**
- * 1. Correct table border color inheritance in all Chrome, Edge, and Safari.
+ * 1. Correct table border color in Chrome, Edge, and Safari.
  * 2. Remove text indentation from table contents in Chrome, Edge, and Safari.
  */
 
 table {
-  border-color: inherit; /* 1 */
+  border-color: currentColor; /* 1 */
   text-indent: 0; /* 2 */
 }
 


### PR DESCRIPTION
I could not find any source that border-color should be inherited.
Firefox, which is not listed as affected, uses "currentColor" and not "inherit".