### PR TITLE
Don't change color inheritance for <hr>

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -39,14 +39,12 @@
 }
 
 /**
- * 1. Add the correct box sizing in Firefox.
- * 2. Correct the inheritance of border color in Firefox.
+ * Add the correct box sizing in Firefox.
  */
 
 :where(hr) {
-  box-sizing: content-box; /* 1 */
-  color: inherit; /* 2 */
-  height: 0; /* 1 */
+  box-sizing: content-box;
+  height: 0;
 }
 
 /* Text-level semantics

--- a/opinionated.css
+++ b/opinionated.css
@@ -47,14 +47,12 @@
 }
 
 /**
- * 1. Add the correct box sizing in Firefox.
- * 2. Correct the inheritance of border color in Firefox.
+ * Add the correct box sizing in Firefox.
  */
 
 :where(hr) {
-  box-sizing: content-box; /* 1 */
-  color: inherit; /* 2 */
-  height: 0; /* 1 */
+  box-sizing: content-box;
+  height: 0;
 }
 
 /* Text-level semantics


### PR DESCRIPTION
Hi :) I think you should remove the `color: inherit` declaration from the \<hr\> element.

The comment for this declaration makes it sound like it is fixing a bug only present in Firefox, but that is incorrect. None of the major browsers support inheritance by default, so there is no reason to include it in `normalize.css`.

I can understand why you might want it in `opinionated.css`, since it feels intuitive that \<hr\> would inherit the text color, but unfortunately, Chromium browsers do not support color inheritance at all, so by adding it you are un-normalizing the styles because the color now will be different between browser engines.

I made a test document and took some screenshots here: https://github.com/sindresorhus/modern-normalize/pull/75