### PR TITLE
Remove `text-indent` declaration from `<table>`

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -91,13 +91,11 @@
  * ========================================================================== */
 
 /**
- * 1. Correct table border color in Chrome, Edge, and Safari.
- * 2. Remove text indentation from table contents in Chrome, Edge, and Safari.
+ * Correct table border color in Chrome, Edge, and Safari.
  */
 
 :where(table) {
-  border-color: currentColor; /* 1 */
-  text-indent: 0; /* 2 */
+  border-color: currentColor;
 }
 
 /* Forms

--- a/opinionated.css
+++ b/opinionated.css
@@ -99,13 +99,11 @@
  * ========================================================================== */
 
 /**
- * 1. Correct table border color in Chrome, Edge, and Safari.
- * 2. Remove text indentation from table contents in Chrome, Edge, and Safari.
+ * Correct table border color in Chrome, Edge, and Safari.
  */
 
 :where(table) {
-  border-color: currentColor; /* 1 */
-  text-indent: 0; /* 2 */
+  border-color: currentColor;
 }
 
 /* Forms


### PR DESCRIPTION
Rule `table { text-indent: 0 }` is fixed in all browsers:

- Chromium: https://github.com/chromium/chromium/commit/b3ba3cc70a9936d2f04e1fcc572dbed5d7e1f3e3
- WebKit: https://github.com/WebKit/WebKit/commit/71f3e1bf7faeb221fa38585e2496a83602268e4b

As a reference, it is already been removed in [sindresorhus/modern-normalize](https://github.com/sindresorhus/modern-normalize/) (see https://github.com/sindresorhus/modern-normalize/commit/a5c26a4d8252bcb4feaa0259cbadd24dad624552).